### PR TITLE
docs: update README dependency examples to 3.0.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,13 +27,13 @@ In short, let’s begin from a brief review of main features provided by logstas
 4. It is auto-configurable Spring Boot library – you don’t have to do anything more than including it as a dependency to your application to make it work
 
 ## Getting started
-The current version of library is `2.2.1`.\
+The current version of library is `3.0.1`.\
 For logging with Spring WebMvc and Logstash:
 ```
 <dependency>
   <groupId>com.github.piomin</groupId>
   <artifactId>logstash-logging-spring-boot-starter</artifactId>
-  <version>2.2.1</version>
+  <version>3.0.1</version>
 </dependency>
 ```
 
@@ -42,7 +42,7 @@ For logging with Spring WebMvc and Loki:
 <dependency>
   <groupId>com.github.piomin</groupId>
   <artifactId>loki-logging-spring-boot-starter</artifactId>
-  <version>2.2.1</version>
+  <version>3.0.1</version>
 </dependency>
 ```
 
@@ -51,7 +51,7 @@ For logging with Spring WebFlux:
 <dependency>
   <groupId>com.github.piomin</groupId>
   <artifactId>reactive-logstash-logging-spring-boot-starter</artifactId>
-  <version>2.2.1</version>
+  <version>3.0.1</version>
 </dependency>
 ```
 
@@ -64,9 +64,9 @@ logging.logstash:
 
 ## Manual add jar to pom.xml
 
-Add `reactive-logstash-logging-spring-boot-starter-2.2.1.pom` to `${basedir}/dependencies`
+Add `reactive-logstash-logging-spring-boot-starter-3.0.1.pom` to `${basedir}/dependencies`
 
-Add `pom.xml` to `${basedir}/dependencies` and rename to `reactive-logstash-logging-spring-boot-starter-2.2.1.pom`
+Add `pom.xml` to `${basedir}/dependencies` and rename to `reactive-logstash-logging-spring-boot-starter-3.0.1.pom`
 
 Add this script to `pom.xml` in plugins section.
 
@@ -78,11 +78,11 @@ Add this script to `pom.xml` in plugins section.
   <configuration>
       <groupId>com.github.piomin</groupId>
       <artifactId>reactive-logstash-logging-spring-boot-starter</artifactId>
-      <version>2.2.1</version>
+      <version>3.0.1</version>
       <packaging>jar</packaging>
-      <file>${basedir}/dependencies/reactive-logstash-logging-spring-boot-starter-2.2.1.jar</file>
+      <file>${basedir}/dependencies/reactive-logstash-logging-spring-boot-starter-3.0.1.jar</file>
       <generatePom>false</generatePom>
-      <pomFile>${basedir}/dependencies/reactive-logstash-logging-spring-boot-starter-2.2.1.RELEASE.pom</pomFile>
+      <pomFile>${basedir}/dependencies/reactive-logstash-logging-spring-boot-starter-3.0.1.RELEASE.pom</pomFile>
   </configuration>
   <executions>
       <execution>


### PR DESCRIPTION
## Summary

This updates the README to use the current project version, `3.0.1`, in the getting-started dependency snippets and manual installation examples.

## Why

The repository release and parent POM are already on `3.0.1`, while the README still references `2.2.1`, which may confuse users copying the setup instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and dependency examples to reflect library version 3.0.1 across Spring WebMvc with Logstash, Spring WebMvc with Loki, and Spring WebFlux configurations, as well as manual jar installation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/piomin/spring-boot-logging/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->