### PR TITLE
fix: honor configured request ID header in reactive filter

### DIFF
--- a/reactive-logging-spring-tests/src/test/java/com/github/piomin/MainControllerReactiveTests.java
+++ b/reactive-logging-spring-tests/src/test/java/com/github/piomin/MainControllerReactiveTests.java
@@ -24,7 +24,10 @@ import pl.piomin.logging.reactive.interceptor.ResponseLoggingInterceptor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "logging.logstash.request-id-header-name=X-Custom-Request-ID"
+)
 @AutoConfigureWebTestClient
 public class MainControllerReactiveTests {
 
@@ -48,6 +51,16 @@ public class MainControllerReactiveTests {
         memoryAppender.start();
     }
 
+    @Test
+    public void shouldUseConfiguredRequestIdHeaderName() {
+        webTestClient.get()
+                .uri("/test/{id}", 1)
+                .header("X-Custom-Request-ID", "custom-request-123")
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectHeader().valueEquals("X-Custom-Request-ID", "custom-request-123");
+    }
+    
     @Test
     public void findById() {
         String res = webTestClient.get()

--- a/reactive-logstash-logging-spring-boot-starter/src/main/java/pl/piomin/logging/reactive/config/ReactiveSpringLoggingAutoConfiguration.java
+++ b/reactive-logstash-logging-spring-boot-starter/src/main/java/pl/piomin/logging/reactive/config/ReactiveSpringLoggingAutoConfiguration.java
@@ -41,7 +41,13 @@ public class ReactiveSpringLoggingAutoConfiguration {
 
     @Bean
     public ReactiveSpringLoggingFilter reactiveSpringLoggingFilter() {
-        return new ReactiveSpringLoggingFilter(generator(), ignorePatterns, logHeaders, useContentLength);
+    	return new ReactiveSpringLoggingFilter(
+    	        generator(),
+    	        ignorePatterns,
+    	        logHeaders,
+    	        useContentLength,
+    	        requestIdHeaderName
+    	);
     }
 
     @Bean

--- a/reactive-logstash-logging-spring-boot-starter/src/main/java/pl/piomin/logging/reactive/filter/ReactiveSpringLoggingFilter.java
+++ b/reactive-logstash-logging-spring-boot-starter/src/main/java/pl/piomin/logging/reactive/filter/ReactiveSpringLoggingFilter.java
@@ -29,9 +29,16 @@ public class ReactiveSpringLoggingFilter implements WebFilter {
     private String ignorePatterns;
     private boolean logHeaders;
     private boolean useContentLength;
+    private String requestIdHeaderName;
     private String requestId;
 
-    public ReactiveSpringLoggingFilter(UniqueIDGenerator generator, String ignorePatterns, boolean logHeaders, boolean useContentLength) {
+    public ReactiveSpringLoggingFilter(
+            UniqueIDGenerator generator,
+            String ignorePatterns,
+            boolean logHeaders,
+            boolean useContentLength,
+            String requestIdHeaderName) {
+    	this.requestIdHeaderName = requestIdHeaderName;
         this.generator = generator;
         this.ignorePatterns = ignorePatterns;
         this.logHeaders = logHeaders;
@@ -47,13 +54,13 @@ public class ReactiveSpringLoggingFilter implements WebFilter {
             final long startTime = System.currentTimeMillis();
             List<String> header = exchange.getRequest().getHeaders().get("Content-Length");
 
-            List<String> requestIdList = exchange.getRequest().getHeaders().get("X-Request-Id");
+            List<String> requestIdList = exchange.getRequest().getHeaders().get(requestIdHeaderName);
             if (requestIdList == null || requestIdList.size() == 0) {
                 requestId = UUID.randomUUID().toString();
             } else {
                 requestId = requestIdList.get(0);
             }
-            exchange.getResponse().getHeaders().set("X-Request-Id", requestId);
+            exchange.getResponse().getHeaders().set(requestIdHeaderName, requestId);
 
             exchange.getMultipartData().subscribe(parts -> {
                 if (!parts.asSingleValueMap().isEmpty()) {


### PR DESCRIPTION
## Summary

This fixes reactive request ID header handling so that
`logging.logstash.request-id-header-name` is honored consistently.

## Changes

- Pass the configured request ID header name into `ReactiveSpringLoggingFilter`
- Replace hardcoded `X-Request-Id` access in the reactive filter
- Add a test verifying a custom request ID header is preserved in the response

## Why

The reactive auto-configuration already exposes a configurable request ID
header name, but the filter still read and wrote a hardcoded header name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable request ID header name. Users can now customize which HTTP header is used for request ID tracking via the `logging.logstash.request-id-header-name` property.

* **Tests**
  * Added test coverage to verify custom request ID header configuration works correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/piomin/spring-boot-logging/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->